### PR TITLE
Do not delete physical hardpoints on systems

### DIFF
--- a/maas/resource_maas_network_interface_physical.go
+++ b/maas/resource_maas_network_interface_physical.go
@@ -18,7 +18,7 @@ func resourceMaasNetworkInterfacePhysical() *schema.Resource {
 		CreateContext: resourceNetworkInterfacePhysicalCreate,
 		ReadContext:   resourceNetworkInterfacePhysicalRead,
 		UpdateContext: resourceNetworkInterfacePhysicalUpdate,
-		DeleteContext: resourceNetworkInterfacePhysicalDelete,
+		DeleteContext: resourceNetworkInterfacePhysicalDisconnect,
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				idParts := strings.Split(d.Id(), "/")
@@ -179,7 +179,7 @@ func resourceNetworkInterfacePhysicalUpdate(ctx context.Context, d *schema.Resou
 	return nil
 }
 
-func resourceNetworkInterfacePhysicalDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkInterfacePhysicalDisconnect(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*client.Client)
 
 	machine, err := getMachine(client, d.Get("machine").(string))
@@ -190,7 +190,7 @@ func resourceNetworkInterfacePhysicalDelete(ctx context.Context, d *schema.Resou
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	if err := client.NetworkInterface.Delete(machine.SystemID, id); err != nil {
+	if _, err := client.NetworkInterface.Disconnect(machine.SystemID, id); err != nil {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
TF state changes can eliminate awareness of resouce elements which then causes the provider to Delete them; a logical absurdity given that these are physical components in physical systems and TF's state describing them does not actually remove hardware from the machine as MaaS is being told to believe.

Update block_device to remove partitions but leave the actual disk visible to MaaS for subsequent action without having to commission the machine again.

Update network_interface_physical to Disconnect instead of Delete so as to avoid removing potentially relevant attributes while not allowing it to logically interfere with operations.